### PR TITLE
fix: long select won't scroll

### DIFF
--- a/src/module/paperSelect.tsx
+++ b/src/module/paperSelect.tsx
@@ -304,8 +304,6 @@ const PaperSelect = ({
               ) : null}
               <ScrollView
                 style={styles.dialogScrollView}
-                persistentScrollbar={true}
-                showsVerticalScrollIndicator={true}
                 keyboardShouldPersistTaps="handled"
               >
                 {multiEnable === true

--- a/src/module/paperSelect.tsx
+++ b/src/module/paperSelect.tsx
@@ -278,43 +278,41 @@ const PaperSelect = ({
             <Dialog.Title style={dialogTitleStyle}>
               {dialogTitle ?? label}
             </Dialog.Title>
-            <Dialog.Content>
-              <Dialog.ScrollArea style={styles.dialogScrollArea}>
-                {!hideSearchBox ? (
-                  <Searchbar
-                    {...searchbarPropsOverrides}
-                    value={searchKey}
-                    placeholder={searchText}
-                    onChangeText={(text: string) => _filterFunction(text)}
-                    style={[styles.searchbar, searchStyle]}
-                  />
-                ) : null}
-                {multiEnable === true && selectAllEnable === true ? (
-                  <TouchableOpacity
-                    style={styles.touchableItem}
-                    onPress={() => {
-                      _checkAll();
-                    }}
-                  >
-                    <CheckboxInput
-                      {...checkboxPropsOverrides}
-                      isChecked={_isCheckedAll()}
-                      label={selectAllText}
-                    />
-                  </TouchableOpacity>
-                ) : null}
-                <ScrollView
-                  style={styles.dialogScrollView}
-                  persistentScrollbar={true}
-                  showsVerticalScrollIndicator={true}
-                  keyboardShouldPersistTaps="handled"
+            <Dialog.ScrollArea>
+              {!hideSearchBox ? (
+                <Searchbar
+                  {...searchbarPropsOverrides}
+                  value={searchKey}
+                  placeholder={searchText}
+                  onChangeText={(text: string) => _filterFunction(text)}
+                  style={[styles.searchbar, searchStyle]}
+                />
+              ) : null}
+              {multiEnable === true && selectAllEnable === true ? (
+                <TouchableOpacity
+                  style={styles.touchableItem}
+                  onPress={() => {
+                    _checkAll();
+                  }}
                 >
-                  {multiEnable === true
-                    ? _renderListForMulti()
-                    : _renderListForSingle()}
-                </ScrollView>
-              </Dialog.ScrollArea>
-            </Dialog.Content>
+                  <CheckboxInput
+                    {...checkboxPropsOverrides}
+                    isChecked={_isCheckedAll()}
+                    label={selectAllText}
+                  />
+                </TouchableOpacity>
+              ) : null}
+              <ScrollView
+                style={styles.dialogScrollView}
+                persistentScrollbar={true}
+                showsVerticalScrollIndicator={true}
+                keyboardShouldPersistTaps="handled"
+              >
+                {multiEnable === true
+                  ? _renderListForMulti()
+                  : _renderListForSingle()}
+              </ScrollView>
+            </Dialog.ScrollArea>
             <Dialog.Actions>
               <Button
                 labelStyle={dialogCloseButtonStyle}
@@ -341,10 +339,6 @@ const styles = StyleSheet.create({
   dialog: {
     backgroundColor: 'white',
     borderRadius: 5,
-  },
-  dialogScrollArea: {
-    paddingVertical: 10,
-    paddingHorizontal: 0,
   },
   dialogScrollView: {
     width: '100%',


### PR DESCRIPTION
A long select list, despite implementation, doesn't actually want to enable scrolling.

I don't know 100% certain if this will actually fix it, but by design the dialog scroll area should not be wrapped within a dialog content, see: https://callstack.github.io/react-native-paper/docs/components/Dialog/DialogScrollArea
I also removed the 2 properties from the ScrollView that controlled the display of the scrollbar.

I limited the dialog height as I always do using:
```ts
            dialogStyle={Object.assign(
                {
                    maxHeight: 0.9 * Dimensions.get("window").height,
                },
                props.dialogStyle,
            )}
```
and whilst it does limit the height, it pushes the buttons down and the scrolling isn't being applied at all.
All of my other dialogs function the same way, and this is the only problematic dialog.